### PR TITLE
feat: refactor handlers so they return deposit data intead of handler response

### DIFF
--- a/src/contracts/Router.sol
+++ b/src/contracts/Router.sol
@@ -37,8 +37,7 @@ contract Router is Context {
         bytes32 resourceID,
         uint64 depositNonce,
         address indexed user,
-        bytes data,
-        bytes handlerResponse
+        bytes data
     );
 
     modifier onlyAllowed() {
@@ -82,16 +81,13 @@ contract Router is Context {
         @param feeData Additional data to be passed to the fee handler.
         @notice Emits {Deposit} event with all necessary parameters and a handler response.
         @return depositNonce deposit nonce for the destination domain.
-        @return handlerResponse a handler response:
-        - ERC20Handler: responds with an empty data.
-        - PermissionlessGenericHandler: responds with an empty data.
      */
     function deposit(
         uint8 destinationDomainID,
         bytes32 resourceID,
         bytes calldata depositData,
         bytes calldata feeData
-    ) external payable whenBridgeNotPaused returns (uint64 depositNonce, bytes memory handlerResponse) {
+    ) external payable whenBridgeNotPaused returns (uint64 depositNonce) {
         if (destinationDomainID == _domainID) revert DepositToCurrentDomain();
 
         address sender = _msgSender();
@@ -114,10 +110,11 @@ contract Router is Context {
 
         depositNonce = ++_depositCounts[destinationDomainID];
 
-        IHandler depositHandler = IHandler(handler);
-        handlerResponse = depositHandler.deposit(resourceID, sender, depositData);
 
-        emit Deposit(destinationDomainID, resourceID, depositNonce, sender, depositData, handlerResponse);
-        return (depositNonce, handlerResponse);
+        IHandler depositHandler = IHandler(handler);
+        bytes memory handlerDepositData = depositHandler.deposit(resourceID, sender, depositData);
+
+        emit Deposit(destinationDomainID, resourceID, depositNonce, sender, handlerDepositData);
+        return depositNonce;
     }
 }

--- a/src/contracts/Router.sol
+++ b/src/contracts/Router.sol
@@ -79,7 +79,7 @@ contract Router is Context {
         @param resourceID ResourceID used to find address of handler to be used for deposit.
         @param depositData Additional data to be passed to specified handler.
         @param feeData Additional data to be passed to the fee handler.
-        @notice Emits {Deposit} event with all necessary parameters and a handler response.
+        @notice Emits {Deposit} event with all necessary parameters.
         @return depositNonce deposit nonce for the destination domain.
      */
     function deposit(

--- a/src/contracts/handlers/ERC20Handler.sol
+++ b/src/contracts/handlers/ERC20Handler.sol
@@ -47,7 +47,8 @@ contract ERC20Handler is IHandler, ERCHandlerHelpers, ERC20Safe {
         uint256 amount;
         uint256 destinationRecipientAddressLen;
         bytes memory destinationRecipientAddress;
-        (amount, destinationRecipientAddressLen, destinationRecipientAddress) = abi.decode(data, (uint256, uint256, bytes));
+        (amount, destinationRecipientAddressLen) = abi.decode(data, (uint, uint));
+        destinationRecipientAddress = bytes(data[64:64 + destinationRecipientAddressLen]);
 
         address tokenAddress = _resourceIDToTokenContractAddress[resourceID];
         if (!_tokenContractAddressToTokenProperties[tokenAddress].isWhitelisted)
@@ -59,7 +60,7 @@ contract ERC20Handler is IHandler, ERCHandlerHelpers, ERC20Safe {
             lockERC20(tokenAddress, depositor, address(this), amount);
         }
 
-        return abi.encode(convertToInternalBalance(tokenAddress, amount), destinationRecipientAddressLen, destinationRecipientAddress);
+        return abi.encodePacked(convertToInternalBalance(tokenAddress, amount), destinationRecipientAddressLen, destinationRecipientAddress);
     }
 
     /**

--- a/src/contracts/handlers/ERC20Handler.sol
+++ b/src/contracts/handlers/ERC20Handler.sol
@@ -60,7 +60,11 @@ contract ERC20Handler is IHandler, ERCHandlerHelpers, ERC20Safe {
             lockERC20(tokenAddress, depositor, address(this), amount);
         }
 
-        return abi.encodePacked(convertToInternalBalance(tokenAddress, amount), destinationRecipientAddressLen, destinationRecipientAddress);
+        return abi.encodePacked(
+            convertToInternalBalance(tokenAddress, amount), 
+            destinationRecipientAddressLen, 
+            destinationRecipientAddress
+        );
     }
 
     /**

--- a/src/contracts/handlers/ERC20Handler.sol
+++ b/src/contracts/handlers/ERC20Handler.sol
@@ -45,7 +45,9 @@ contract ERC20Handler is IHandler, ERCHandlerHelpers, ERC20Safe {
         bytes calldata data
     ) external override onlyBridge returns (bytes memory) {
         uint256 amount;
-        (amount) = abi.decode(data, (uint));
+        uint256 destinationRecipientAddressLen;
+        bytes memory destinationRecipientAddress;
+        (amount, destinationRecipientAddressLen, destinationRecipientAddress) = abi.decode(data, (uint256, uint256, bytes));
 
         address tokenAddress = _resourceIDToTokenContractAddress[resourceID];
         if (!_tokenContractAddressToTokenProperties[tokenAddress].isWhitelisted)
@@ -57,7 +59,7 @@ contract ERC20Handler is IHandler, ERCHandlerHelpers, ERC20Safe {
             lockERC20(tokenAddress, depositor, address(this), amount);
         }
 
-        return abi.encodePacked(convertToInternalBalance(tokenAddress, amount));
+        return abi.encode(convertToInternalBalance(tokenAddress, amount), destinationRecipientAddressLen, destinationRecipientAddress);
     }
 
     /**

--- a/src/contracts/handlers/ERCHandlerHelpers.sol
+++ b/src/contracts/handlers/ERCHandlerHelpers.sol
@@ -121,17 +121,17 @@ contract ERCHandlerHelpers is IERCHandler {
         @param tokenAddress Address of contract to be used when executing proposals.
         @param amount Decimals value to be set for {contractAddress}.
     */
-    function convertToInternalBalance(address tokenAddress, uint256 amount) internal view returns (bytes memory) {
+    function convertToInternalBalance(address tokenAddress, uint256 amount) internal view returns (uint256) {
         Decimals memory decimals = _tokenContractAddressToTokenProperties[tokenAddress].decimals;
         uint256 convertedBalance;
         if (!decimals.isSet) {
-            return "";
+            return amount;
         } else if (decimals.externalDecimals >= DEFAULT_DECIMALS) {
             convertedBalance = amount / (10 ** (decimals.externalDecimals - DEFAULT_DECIMALS));
         } else {
             convertedBalance = amount * (10 ** (DEFAULT_DECIMALS - decimals.externalDecimals));
         }
 
-        return abi.encodePacked(convertedBalance);
+        return convertedBalance;
     }
 }

--- a/src/contracts/handlers/PermissionlessGenericHandler.sol
+++ b/src/contracts/handlers/PermissionlessGenericHandler.sol
@@ -109,7 +109,7 @@ contract PermissionlessGenericHandler is IHandler {
             After this, the target contract will get the following:
             executeFuncSignature(address executionDataDepositor, uint[] uintArray, address addr)
      */
-    function deposit(bytes32 resourceID, address depositor, bytes calldata data) external view returns (bytes memory) {
+    function deposit(bytes32 resourceID, address depositor, bytes calldata data) external pure returns (bytes memory) {
         require(data.length >= 76, "Incorrect data length"); // 32 + 2 + 1 + 1 + 20 + 20
 
         uint256 maxFee;
@@ -141,6 +141,7 @@ contract PermissionlessGenericHandler is IHandler {
 
         require(maxFee < MAX_FEE, "requested fee too large");
         require(depositor == executionDataDepositor, "incorrect depositor in deposit data");
+        return data;
     }
 
     /**

--- a/test/contractBridge/depositERC20.test.ts
+++ b/test/contractBridge/depositERC20.test.ts
@@ -188,7 +188,6 @@ describe("Bridge - [deposit - ERC20]", () => {
         expectedDepositNonce,
         await depositorAccount.getAddress(),
         depositData.toLowerCase(),
-        "0x",
       );
 
     const depositTx2 = routerInstance
@@ -203,7 +202,6 @@ describe("Bridge - [deposit - ERC20]", () => {
         expectedDepositNonce + 1,
         await depositorAccount.getAddress(),
         depositData.toLowerCase(),
-        "0x",
       );
   });
 

--- a/test/e2e/erc20/decimals/bothChainsNot18Decimals.test.ts
+++ b/test/e2e/erc20/decimals/bothChainsNot18Decimals.test.ts
@@ -8,7 +8,6 @@ import {
   deployBridgeContracts,
   createResourceID,
   createERCDepositData,
-  createDepositProposalDataFromHandlerResponse,
   toHex,
 } from "../../../helpers";
 import type {

--- a/test/e2e/erc20/decimals/bothChainsNot18Decimals.test.ts
+++ b/test/e2e/erc20/decimals/bothChainsNot18Decimals.test.ts
@@ -206,6 +206,9 @@ describe("E2E ERC20 - Two EVM Chains both with decimal places != 18", () => {
 
     await expect(originDepositTx).not.to.be.reverted;
 
+    const originExpectedDepositData =
+      toHex(relayerConvertedAmount.toString(), 32) +
+      originDepositData.substring(66);
     // check that deposited amount converted to 18 decimal places is
     // emitted in handlerResponse
     await expect(originDepositTx)
@@ -215,23 +218,13 @@ describe("E2E ERC20 - Two EVM Chains both with decimal places != 18", () => {
         originResourceID.toLowerCase(),
         expectedDepositNonce,
         await depositorAccount.getAddress(),
-        originDepositData.toLowerCase(),
-        toHex(relayerConvertedAmount.toString(), 32),
-      );
-
-    // this mocks depositProposal data for executing on
-    // destination chain which is returned from relayers
-    const originDepositProposalData =
-      await createDepositProposalDataFromHandlerResponse(
-        originDepositTx,
-        20,
-        await recipientAccount.getAddress(),
+        originExpectedDepositData.toLowerCase(),
       );
 
     const originDomainProposal = {
       originDomainID: originDomainID,
       depositNonce: expectedDepositNonce,
-      data: originDepositProposalData,
+      data: originExpectedDepositData,
       resourceID: destinationResourceID,
     };
 
@@ -282,6 +275,9 @@ describe("E2E ERC20 - Two EVM Chains both with decimal places != 18", () => {
       );
     await expect(destinationDepositTx).not.to.be.reverted;
 
+    const destinationExepectedDepositData =
+      toHex(relayerConvertedAmount.toString(), 32) +
+      destinationDepositData.substring(66);
     // check that deposited amount converted to 18 decimal places is
     // emitted in handlerResponse
     await expect(destinationDepositTx)
@@ -291,23 +287,13 @@ describe("E2E ERC20 - Two EVM Chains both with decimal places != 18", () => {
         destinationResourceID.toLowerCase(),
         expectedDepositNonce,
         await recipientAccount.getAddress(),
-        destinationDepositData.toLowerCase(),
-        toHex(relayerConvertedAmount.toString(), 32),
-      );
-
-    // this mocks depositProposal data for executing on
-    // destination chain which is returned from relayers
-    const destinationDepositProposalData =
-      await createDepositProposalDataFromHandlerResponse(
-        destinationDepositTx,
-        20,
-        await depositorAccount.getAddress(),
+        destinationExepectedDepositData.toLowerCase(),
       );
 
     const destinationDomainProposal = {
       originDomainID: destinationDomainID,
       depositNonce: expectedDepositNonce,
-      data: destinationDepositProposalData,
+      data: destinationExepectedDepositData,
       resourceID: originResourceID,
     };
 

--- a/test/e2e/erc20/decimals/oneChainNot18Decimals.test.ts
+++ b/test/e2e/erc20/decimals/oneChainNot18Decimals.test.ts
@@ -8,7 +8,7 @@ import {
   deployBridgeContracts,
   createResourceID,
   createERCDepositData,
-  createDepositProposalDataFromHandlerResponse,
+  getDepositEventData,
 } from "../../../helpers";
 import type {
   Bridge,
@@ -224,19 +224,10 @@ describe("E2E ERC20 - Two EVM Chains, one with decimal places == 18, other with 
       );
     await expect(originDepositTx).not.to.be.reverted;
 
-    // this mocks depositProposal data for executing on
-    // destination chain which is returned from relayers
-    const originDepositProposalData =
-      await createDepositProposalDataFromHandlerResponse(
-        originDepositTx,
-        20,
-        await recipientAccount.getAddress(),
-      );
-
     const originDomainProposal = {
       originDomainID: originDomainID,
       depositNonce: expectedDepositNonce,
-      data: originDepositProposalData,
+      data: await getDepositEventData(originDepositTx),
       resourceID: destinationResourceID,
     };
 
@@ -297,7 +288,6 @@ describe("E2E ERC20 - Two EVM Chains, one with decimal places == 18, other with 
         expectedDepositNonce,
         await recipientAccount.getAddress(),
         destinationDepositData.toLowerCase(),
-        "0x",
       );
 
     // Recipient should have a balance of 0 (deposit amount)

--- a/test/e2e/erc20/decimals/oneChainWith0Decimals.test.ts
+++ b/test/e2e/erc20/decimals/oneChainWith0Decimals.test.ts
@@ -8,7 +8,7 @@ import {
   deployBridgeContracts,
   createResourceID,
   createERCDepositData,
-  createDepositProposalDataFromHandlerResponse,
+  getDepositEventData,
 } from "../../../helpers";
 import type {
   Bridge,
@@ -226,19 +226,10 @@ describe("E2E ERC20 - Two EVM Chains, one with decimal places == 18, other with 
 
     await expect(originDepositTx).not.to.be.reverted;
 
-    // this mocks depositProposal data for executing on
-    // destination chain which is returned from relayers
-    const originDepositProposalData =
-      await createDepositProposalDataFromHandlerResponse(
-        originDepositTx,
-        20,
-        await recipientAccount.getAddress(),
-      );
-
     const originDomainProposal = {
       originDomainID: originDomainID,
       depositNonce: expectedDepositNonce,
-      data: originDepositProposalData,
+      data: getDepositEventData(originDepositTx),
       resourceID: destinationResourceID,
     };
 
@@ -299,7 +290,6 @@ describe("E2E ERC20 - Two EVM Chains, one with decimal places == 18, other with 
         expectedDepositNonce,
         await recipientAccount.getAddress(),
         destinationDepositData.toLowerCase(),
-        "0x",
       );
 
     // Recipient should have a balance of 0 (deposit amount)

--- a/test/handlers/erc20/deposit.test.ts
+++ b/test/handlers/erc20/deposit.test.ts
@@ -118,7 +118,6 @@ describe("ERC20Handler - [Deposit ERC20]", () => {
           lenRecipientAddress,
           recipientAccount,
         ).toLowerCase(),
-        "0x",
       );
   });
 
@@ -151,7 +150,6 @@ describe("ERC20Handler - [Deposit ERC20]", () => {
           lenRecipientAddress,
           recipientAccount,
         ),
-        "0x",
       );
   });
 

--- a/test/handlers/fee/basic/collectFee.test.ts
+++ b/test/handlers/fee/basic/collectFee.test.ts
@@ -195,7 +195,6 @@ describe("BasicFeeHandler - [collectFee]", () => {
         expectedDepositNonce,
         await depositorAccount.getAddress(),
         erc20depositData.toLowerCase(),
-        "0x",
       );
 
     await expect(depositTx)
@@ -415,7 +414,6 @@ describe("BasicFeeHandler - [collectFee]", () => {
         expectedDepositNonce,
         await depositorAccount.getAddress(),
         erc20depositData.toLowerCase(),
-        "0x",
       );
 
     await expect(depositTx)

--- a/test/handlers/fee/percentage/collectFee.test.ts
+++ b/test/handlers/fee/percentage/collectFee.test.ts
@@ -141,7 +141,6 @@ describe("PercentageFeeHandler - [collectFee]", () => {
         expectedDepositNonce,
         await depositorAccount.getAddress(),
         depositData.toLowerCase(),
-        "0x",
       );
 
     await expect(depositTx)
@@ -269,7 +268,6 @@ describe("PercentageFeeHandler - [collectFee]", () => {
         expectedDepositNonce,
         await depositorAccount.getAddress(),
         depositData.toLowerCase(),
-        "0x",
       );
 
     await expect(depositTx)

--- a/test/handlers/generic/permissionlessDeposit.test.ts
+++ b/test/handlers/generic/permissionlessDeposit.test.ts
@@ -99,7 +99,6 @@ describe("PermissionlessGenericHandler - [deposit]", () => {
         expectedDepositNonce,
         await depositorAccount.getAddress(),
         depositData.toLowerCase(),
-        "0x",
       );
   });
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 import { ethers } from "hardhat";
-import type { TransactionResponse } from "ethers";
+import type { TransactionReceipt, TransactionResponse } from "ethers";
 import { generateAccessControlFuncSignatures } from "../scripts/utils";
 import type { Bridge, Router, Executor } from "../typechain-types";
 
@@ -126,16 +126,14 @@ export async function deployBridgeContracts(
   return [bridgeInstance, routerInstance, executorInstance];
 }
 
-export async function createDepositProposalDataFromHandlerResponse(
+export async function getDepositEventData(
   depositTx: TransactionResponse,
-  lenRecipientAddress: number,
-  recipientAccount: string,
 ): Promise<string> {
-  return createERCDepositData(
-    BigInt((await depositTx.wait(1)).logs[2]["args"][5]).toString(),
-    lenRecipientAddress,
-    recipientAccount,
-  );
+  return (
+    ((await depositTx.wait(1)) as TransactionReceipt).logs[2] as unknown as {
+      args: string[];
+    }
+  )["args"][4];
 }
 
 // This helper can be used to prepare execution data for PermissionlessGenericHandler
@@ -170,6 +168,6 @@ module.exports = {
   createResourceID,
   decimalToPaddedBinary,
   deployBridgeContracts,
-  createDepositProposalDataFromHandlerResponse,
   createPermissionlessGenericExecutionData,
+  getDepositEventData,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Refactor handlers to they modify and return the deposit data and deprecate the `handleResponse` field.
Deposit data has to be modifed as the data submitted and stored on the source chain must be the same as the data sent to the `executeProposals` function on the destination for us to be able to do storage proofs.

## Description
<!--- Describe your changes in detail -->

## Related Issue Or Context
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Otherwise, describe context and motivation for change herre -->

Closes: #3 

## How Has This Been Tested? Testing details.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [x] I have updated the documentation locally and in Sygma-docs.
- [x] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
