### PR TITLE
feat: expose method for marking nonce as used

### DIFF
--- a/test/contractBridge/admin.test.ts
+++ b/test/contractBridge/admin.test.ts
@@ -298,7 +298,7 @@ describe("Bridge - [admin]", () => {
     );
   });
 
-  // Set nonce
+  // Nonces manipulation
 
   it("Should set nonce", async () => {
     const nonce = 3;
@@ -329,6 +329,31 @@ describe("Bridge - [admin]", () => {
         .connect(tokenOwnerAccount)
         .adminSetDepositNonce(domainID, newNonce),
     ).to.be.revertedWith("Does not allow decrements of the nonce");
+  });
+
+  it("Should require admin role to mark nonce as used", async () => {
+    const nonce = 5;
+    await expect(
+      executorInstance
+        .connect(nonAdminAccount)
+        .adminMarkNonceAsUsed(domainID, nonce),
+    ).to.be.revertedWithCustomError(
+      executorInstance,
+      "AccessNotAllowed(address,bytes4)",
+    );
+  });
+
+  it("Should successfully mark nonce as used", async () => {
+    const usedNonce = 5;
+    await executorInstance
+      .connect(tokenOwnerAccount)
+      .adminMarkNonceAsUsed(domainID, usedNonce);
+    const isNonceUsed = await executorInstance.isProposalExecuted(
+      domainID,
+      usedNonce,
+    );
+
+    assert.isTrue(isNonceUsed, "Nonce wasn't successfully marked as used");
   });
 
   // Change access control contract


### PR DESCRIPTION
## Description
Exposes method that marks a certain nonce for a domain as used - this is required in the flow of when funds are stuck and we return funds to user.

## Related Issue Or Context
Closes: #24 

## How Has This Been Tested? Testing details.
* unit tests
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in Sygma-docs.
- [x] I have added tests to cover my changes.
- [x] I have ensured that all the checks are passing and green, I've signed the CLA bot
