### PR TITLE
fix: revert with custom error for 0 conversion amounts

### DIFF
--- a/src/contracts/handlers/ERCHandlerHelpers.sol
+++ b/src/contracts/handlers/ERCHandlerHelpers.sol
@@ -29,6 +29,7 @@ contract ERCHandlerHelpers is IERCHandler {
     }
 
     error ContractAddressNotWhitelisted(address contractAddress);
+    error DepositAmountTooSmall(uint256 depositAmount);
 
     // resourceID => token contract address
     mapping(bytes32 => address) public _resourceIDToTokenContractAddress;
@@ -130,6 +131,10 @@ contract ERCHandlerHelpers is IERCHandler {
             convertedBalance = amount / (10 ** (decimals.externalDecimals - DEFAULT_DECIMALS));
         } else {
             convertedBalance = amount * (10 ** (DEFAULT_DECIMALS - decimals.externalDecimals));
+        }
+
+        if (convertedBalance == 0) {
+            revert DepositAmountTooSmall(amount);
         }
 
         return convertedBalance;


### PR DESCRIPTION
## Description
If conversion amount from source chain to Bridge internal decimals (18) would result in 0 converted amount, revert with custom error `DepositAmountTooSmall`

## How Has This Been Tested? Testing details.
unit tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in Sygma-docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
