### PR TITLE
chore: add hardhat cli command to configure sygma-x after deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Requires `yarn` and `@nomicfoundation/hardhat`.
     `test` - Runs mocha tests <br>
     `typechain` - Generate Typechain typings for compiled contracts <br>
     `verify` - Verifies contract on Etherscan <br>
+  * custom hardhat commands: <bt>
+    `configure-sygma --file [path to config json]` - configures sygma after deployments
   * custom commands: <br>
     `yarn run test`: Runs tests.
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -6,6 +6,8 @@ import "@nomicfoundation/hardhat-chai-matchers";
 import "@nomicfoundation/hardhat-verify";
 import "hardhat-deploy";
 
+import "./scripts/tasks";
+
 dotenv.config();
 
 const config: HardhatUserConfig = {
@@ -20,6 +22,10 @@ const config: HardhatUserConfig = {
     },
   },
   networks: {
+    localhost: {
+      live: false,
+      saveDeployments: true,
+    },
     sepolia: {
       url: `${process.env.SEPOLIA_PROVIDER_URL}`,
       accounts: [

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "compile": "npx hardhat compile",
     "coverage": "npx hardhat coverage",
+    "configure:sygma": "npx hardhat configure-sygma",
     "deploy": "npx hardhat deploy --network",
     "lint:typescript": "eslint 'test/**/*.ts' 'scripts/**/*.ts'",
     "lint:typescript:fix": "prettier --config .prettierrc.json --write 'scripts/**/*.ts' 'test/**/*.ts' 'hardhat.config.ts'",
@@ -24,7 +25,7 @@
     "@chainsafe/eslint-config": "^2.1.1",
     "@metamask/eth-sig-util": "^7.0.0",
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.2",
-    "@nomicfoundation/hardhat-ethers": "^3.0.4",
+    "@nomicfoundation/hardhat-ethers": "^3.0.5",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.10",
     "@nomicfoundation/hardhat-toolbox": "^3.0.0",
     "@nomicfoundation/hardhat-verify": "^1.0.0",

--- a/scripts/environments/testnet.json
+++ b/scripts/environments/testnet.json
@@ -1,0 +1,88 @@
+{
+  "localhost": {
+    "domainID": "1",
+    "specterAddress": "0x455E5AA18469bC6ccEF49594645666C587A3a71B",
+    "routerAddress": "0x455E5AA18469bC6ccEF49594645666C587A3a71B",
+    "executorAddress": "0x455E5AA18469bC6ccEF49594645666C587A3a71B",
+    "verifiersAddresses": ["0x990D2FcF3AEe2D543aCf75CEc053eF16c0eAfAA1","0x990D2FcF3AEe2D543aCf75CEc053eF16c0eAfAA1"],
+    "securityModel": 1,
+    "slotIndex": 1,
+    "access": {
+      "feeRouterAdmin": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+      "feeHandlerAdmin": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+      "accessControl": {
+        "0x80ae1c28": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0xffaac0eb": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0x9d33b6d4": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0x8b63aebf": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0x8c0c2631": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0xedc20c3c": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0xd15ef64e": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0x8a3234c7": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0xbd2a1820": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0xd2e5fae9": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0xd8236744": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0x366b4885": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0x6ba6db6b": "0xe9f23A8289764280697a03aC06795eA92a170e42"
+      }
+    },
+    "erc20": [
+      {
+        "name": "ERC20LRTest",
+        "symbol": "ERC20TST",
+        "address": "0x455E5AA18469bC6ccEF49594645666C587A3a71B",
+        "resourceID": "0x0000000000000000000000000000000000000000000000000000000000000300",
+        "feeType": "undefined",
+        "strategy": "lr",
+        "decimals": "18"
+      }
+    ],
+    "permissionlessGeneric": {
+      "resourceID": "0x0000000000000000000000000000000000000000000000000000000000000500",
+      "feeType": "undefined"
+    }
+  },
+  "sepolia": {
+    "domainID": "2",
+    "specterAddress": "0x455E5AA18469bC6ccEF49594645666C587A3a71B",
+    "routerAddress": "0x455E5AA18469bC6ccEF49594645666C587A3a71B",
+    "executorAddress": "0x455E5AA18469bC6ccEF49594645666C587A3a71B",
+    "verifiersAddresses": ["0x990D2FcF3AEe2D543aCf75CEc053eF16c0eAfAA1","0x990D2FcF3AEe2D543aCf75CEc053eF16c0eAfAA1"],
+    "securityModel": 1,
+    "slotIndex": 1,
+    "access": {
+      "feeRouterAdmin": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+      "feeHandlerAdmin": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+      "accessControl": {
+        "0x80ae1c28": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0xffaac0eb": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0x9d33b6d4": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0x8b63aebf": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0x8c0c2631": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0xedc20c3c": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0xd15ef64e": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0x8a3234c7": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0xbd2a1820": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0xd2e5fae9": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0xd8236744": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0x366b4885": "0xe9f23A8289764280697a03aC06795eA92a170e42",
+        "0x6ba6db6b": "0xe9f23A8289764280697a03aC06795eA92a170e42"
+      }
+    },
+    "erc20": [
+      {
+        "name": "ERC20LRTest",
+        "symbol": "ERC20TST",
+        "address": "0x455E5AA18469bC6ccEF49594645666C587A3a71B",
+        "resourceID": "0x0000000000000000000000000000000000000000000000000000000000000300",
+        "feeType": "undefined",
+        "strategy": "lr",
+        "decimals": "18"
+      }
+    ],
+    "permissionlessGeneric": {
+      "resourceID": "0x0000000000000000000000000000000000000000000000000000000000000500",
+      "feeType": "undefined"
+    }
+  }
+}

--- a/scripts/migrations/01_deployCoreContracts.ts
+++ b/scripts/migrations/01_deployCoreContracts.ts
@@ -12,8 +12,6 @@ const deployFunc: DeployFunction = async function ({
   const { deployer } = await getNamedAccounts();
 
   const domainID = process.env.BRIDGE_DOMAIN_ID;
-  const reannounceAdminAddress =
-    process.env.FUNCTIONS_ACCESS_ADMIN_ADDRESS ?? deployer;
   const spectreDomainIDs = process.env.SPECTRE_DOMAIN_IDS ?? 0;
   const spectreAddresses = process.env.SPECTRE_ADDRESSES ?? ethers.ZeroAddress;
 
@@ -33,7 +31,7 @@ const deployFunc: DeployFunction = async function ({
 
     const accessControlArgs = [
       accessControlFuncSignatures,
-      Array(accessControlFuncSignatures.length).fill(reannounceAdminAddress),
+      Array(accessControlFuncSignatures.length).fill(deployer),
     ];
     const accessControlInstance = await deploy("AccessControlSegregator", {
       from: deployer,
@@ -43,9 +41,6 @@ const deployFunc: DeployFunction = async function ({
     await verifyContract(accessControlInstance, accessControlArgs);
     console.log(
       `Access control segregator contract successfully deployed to: ${accessControlInstance.address}`,
-    );
-    console.log(
-      `Granted all admin functions rights to: ${reannounceAdminAddress}`,
     );
 
     const specterProxyArgs = [spectreDomainIDs, spectreAddresses];

--- a/scripts/migrations/02_deployHandlers.ts
+++ b/scripts/migrations/02_deployHandlers.ts
@@ -1,6 +1,7 @@
 import type { HardhatRuntimeEnvironment } from "hardhat/types";
 import type { DeployFunction } from "hardhat-deploy/dist/types";
 
+import { DEPLOYMENTS } from "../types";
 import { verifyContract } from "../utils";
 
 const deployFunc: DeployFunction = async function ({
@@ -10,15 +11,9 @@ const deployFunc: DeployFunction = async function ({
   const { deploy } = deployments;
   const { deployer } = await getNamedAccounts();
   try {
-    const bridgeInstance = await deployments.get("Bridge");
-    const routerInstance = await deployments.get("Router");
-    const executorInstance = await deployments.get("Executor");
+    const bridgeInstance = await deployments.get(DEPLOYMENTS.Bridge);
 
-    const erc20HandlerArgs = [
-      bridgeInstance.address,
-      routerInstance.address,
-      executorInstance.address,
-    ];
+    const erc20HandlerArgs = [bridgeInstance.address];
     const erc20HandlerInstance = await deploy("ERC20Handler", {
       from: deployer,
       args: erc20HandlerArgs,
@@ -29,10 +24,7 @@ const deployFunc: DeployFunction = async function ({
       `ERC20 handler contract successfully deployed to: ${erc20HandlerInstance.address}`,
     );
 
-    const permissionlessGenericHandlerArgs = [
-      bridgeInstance.address,
-      executorInstance.address,
-    ];
+    const permissionlessGenericHandlerArgs = [bridgeInstance.address];
     const permissionlessGenericHandlerInstance = await deploy(
       "PermissionlessGenericHandler",
       {
@@ -49,7 +41,7 @@ const deployFunc: DeployFunction = async function ({
       `Permissionless generic handler contract successfully deployed to: ${permissionlessGenericHandlerInstance.address}`,
     );
 
-    const feeHandlerRouterArgs = [routerInstance.address];
+    const feeHandlerRouterArgs = [bridgeInstance.address];
     const feeHandlerRouterInstance = await deploy("FeeHandlerRouter", {
       from: deployer,
       args: feeHandlerRouterArgs,
@@ -63,7 +55,6 @@ const deployFunc: DeployFunction = async function ({
     const basicFeeHandlerArgs = [
       bridgeInstance.address,
       feeHandlerRouterInstance.address,
-      routerInstance.address,
     ];
     const basicFeeHandlerInstance = await deploy("BasicFeeHandler", {
       from: deployer,
@@ -78,7 +69,6 @@ const deployFunc: DeployFunction = async function ({
     const percentageFeeHandlerArgs = [
       bridgeInstance.address,
       feeHandlerRouterInstance.address,
-      routerInstance.address,
     ];
     const percentageFeeHandlerInstance = await deploy(
       "PercentageERC20FeeHandlerEVM",

--- a/scripts/tasks/configureSygma.ts
+++ b/scripts/tasks/configureSygma.ts
@@ -1,0 +1,119 @@
+import { task } from "hardhat/config";
+
+import { getNetworksConfig } from "../../test/deployments";
+import { DEPLOYMENTS } from "../types";
+
+const EMPTY_SET_RESOURCE_DATA = "0x";
+
+task("configure-sygma", "Configures all Sygma contracts after deployments")
+  .addParam("file", "Environment for which you want to configure Sygma")
+  .setAction(async (_, hre) => {
+    const networksConfig = getNetworksConfig();
+    const currentNetworkConfig = networksConfig[hre.network.name];
+    // remove the current network from networks config
+    delete networksConfig[hre.network.name];
+
+    const accessSegregatorDeployment = await hre.deployments.get(
+      DEPLOYMENTS.AccessSegregator,
+    );
+    const accessControlInstance = await hre.ethers.getContractAt(
+      DEPLOYMENTS.AccessSegregator,
+      accessSegregatorDeployment.address,
+    );
+
+    const spectreProxyDeployment = await hre.deployments.get(
+      DEPLOYMENTS.SpectreProxy,
+    );
+    const spectreProxyInstance = await hre.ethers.getContractAt(
+      DEPLOYMENTS.SpectreProxy,
+      spectreProxyDeployment.address,
+    );
+
+    const bridgeDeployment = await hre.deployments.get(DEPLOYMENTS.Bridge);
+    const bridgeInstance = await hre.ethers.getContractAt(
+      DEPLOYMENTS.Bridge,
+      bridgeDeployment.address,
+    );
+
+    const erc20HandlerDeployment = await hre.deployments.get(
+      DEPLOYMENTS.ERC20Handler,
+    );
+    const erc20HandlerInstance = await hre.ethers.getContractAt(
+      DEPLOYMENTS.ERC20Handler,
+      erc20HandlerDeployment.address,
+    );
+
+    const executorDeployment = await hre.deployments.get(DEPLOYMENTS.Executor);
+    const executorInstance = await hre.ethers.getContractAt(
+      DEPLOYMENTS.Executor,
+      executorDeployment.address,
+    );
+
+    await spectreProxyInstance.adminSetSpectreAddress(
+      currentNetworkConfig.domainID,
+      currentNetworkConfig.specterAddress,
+    );
+
+    await bridgeInstance.adminChangeRouterAddress(
+      currentNetworkConfig.routerAddress,
+    );
+
+    await bridgeInstance.adminChangeExecutorAddress(
+      currentNetworkConfig.executorAddress,
+    );
+
+    for (const network of Object.values(networksConfig)) {
+      await executorInstance.adminChangeSlotIndex(
+        network.domainID,
+        network.slotIndex,
+      );
+
+      await executorInstance.adminSetVerifiers(
+        network.securityModel,
+        network.verifiersAddresses,
+      );
+    }
+
+    for (const erc20Token of currentNetworkConfig.erc20) {
+      const erc20HandlerAddress = await erc20HandlerInstance.getAddress();
+      const erc20TokenInstance = await hre.ethers.getContractAt(
+        "ERC20PresetMinterPauser",
+        erc20Token.address,
+      );
+
+      await bridgeInstance.adminSetResource(
+        erc20HandlerAddress,
+        erc20Token.resourceID,
+        await erc20TokenInstance.getAddress(),
+        EMPTY_SET_RESOURCE_DATA,
+      );
+
+      // strategy can be either mb (mint/burn) or lr (lock/release)
+      if (erc20Token.strategy == "mb") {
+        await erc20TokenInstance.grantRole(
+          await erc20TokenInstance.MINTER_ROLE(),
+          erc20HandlerAddress,
+        );
+        await bridgeInstance.adminSetBurnable(
+          erc20HandlerAddress,
+          erc20Token.address,
+        );
+      }
+    }
+
+    // check json config if func access right should be renounced
+    const reannounceAdminAddress = process.env.FUNCTIONS_ACCESS_ADMIN_ADDRESS;
+    if (reannounceAdminAddress) {
+      for (const [func, admin] of Object.entries(
+        currentNetworkConfig.access.accessControl,
+      )) {
+        console.log("Granting access for function %s to %s", func, admin);
+        await accessControlInstance.grantAccess(func, admin);
+        console.log(
+          `Granted all admin functions rights to: ${reannounceAdminAddress}`,
+        );
+        await accessControlInstance.grantAccess(func, admin);
+      }
+    }
+    console.log("Sygma-x successfully configured");
+  });

--- a/scripts/tasks/index.ts
+++ b/scripts/tasks/index.ts
@@ -1,0 +1,1 @@
+export * from "./configureSygma";

--- a/scripts/types.ts
+++ b/scripts/types.ts
@@ -1,0 +1,46 @@
+export enum DEPLOYMENTS {
+  AccessSegregator = "AccessControlSegregator",
+  SpectreProxy = "SpectreProxy",
+  Bridge = "Bridge",
+  Router = "Router",
+  Executor = "Executor",
+  ERC20Handler = "ERC20Handler",
+}
+
+export type Token = {
+  name: string;
+  symbol: string;
+  address: string;
+  resourceID: string;
+  feeType: string;
+  strategy: "lr" | "mb";
+  decimals: string;
+};
+
+export enum FeeHandlerType {
+  BASIC = "basic",
+  PERCENTAGE = "percentage",
+  UNDEFINED = "undefined",
+}
+
+export type NetworkConfig = {
+  domainID: string;
+  specterAddress: string;
+  routerAddress: string;
+  executorAddress: string;
+  verifiersAddresses: Array<string>;
+  slotIndex: number;
+  securityModel: number;
+  access: {
+    feeRouterAdmin: string;
+    feeHandlerAdmin: string;
+    accessControl: {
+      [key: string]: string;
+    };
+  };
+  erc20: Array<Token>;
+  permissionlessGeneric: {
+    resourceID: string;
+    feeType: FeeHandlerType;
+  };
+};

--- a/test/deployments.ts
+++ b/test/deployments.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from "fs";
+
+import type { NetworkConfig } from "../scripts/types";
+import type { Bridge, Executor, SpectreProxy } from "../typechain-types";
+
+const DEFAULT_CONFIG_PATH = "./scripts/environments/testnet.json";
+
+export function getNetworksConfig(): {
+  [key: string]: NetworkConfig;
+} {
+  let path: string = "";
+  if (!path) {
+    path = DEFAULT_CONFIG_PATH;
+  }
+  return JSON.parse(readFileSync(path).toString()) as unknown as {
+    [key: string]: NetworkConfig;
+  };
+}
+
+export async function setSpectreAddress(
+  spectreProxyInstance: SpectreProxy,
+  domainID: number,
+  spectreAddress: string,
+): Promise<void> {
+  // check if we want to pass array and iterate
+  await spectreProxyInstance.adminSetSpectreAddress(domainID, spectreAddress);
+}
+
+export async function setRouterAddress(
+  bridgeInstance: Bridge,
+  routerAddress: string,
+): Promise<void> {
+  await bridgeInstance.adminChangeRouterAddress(routerAddress);
+}
+
+export async function setExecutorAddress(
+  bridgeInstance: Bridge,
+  executorAddress: string,
+): Promise<void> {
+  await bridgeInstance.adminChangeRouterAddress(executorAddress);
+}
+
+export async function setResources(
+  bridgeInstance: Bridge,
+  handlerAddress: string,
+  resourceID: string,
+  contractAddress: string,
+  args?: string,
+): Promise<void> {
+  await bridgeInstance.adminSetResource(
+    handlerAddress,
+    resourceID,
+    contractAddress,
+    args ?? "",
+  );
+}
+
+export async function setVerifiers(
+  executorInstance: Executor,
+  securityModel: number,
+  verifiersAddresses: Array<string>,
+): Promise<void> {
+  await executorInstance.adminSetVerifiers(securityModel, verifiersAddresses);
+}
+
+export async function changeSlotIndex(
+  executorInstance: Executor,
+  securityModel: number,
+  slotIndex: number,
+): Promise<void> {
+  await executorInstance.adminChangeSlotIndex(securityModel, slotIndex);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -807,7 +807,7 @@
     deep-eql "^4.0.1"
     ordinal "^1.0.3"
 
-"@nomicfoundation/hardhat-ethers@^3.0.4":
+"@nomicfoundation/hardhat-ethers@^3.0.5":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-3.0.5.tgz#0422c2123dec7c42e7fb2be8e1691f1d9708db56"
   integrity sha512-RNFe8OtbZK6Ila9kIlHp0+S80/0Bu/3p41HUpaRIoHLm6X3WekTd83vob3rE54Duufu1edCiBDxspBzi2rxHHw==


### PR DESCRIPTION
## Description
Adds custom command (`configure-sygma`) to hardhat cli. This commands configures everything (except fees at the moment) to use sygma after deployments.

## How Has This Been Tested? Testing details.
manual tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation

## Checklist:
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have ensured that all acceptance criteria (or expected behavior) from issue are met
- [ ] I have updated the documentation locally and in Sygma-docs.
- [ ] I have added tests to cover my changes.
- [ ] I have ensured that all the checks are passing and green, I've signed the CLA bot
